### PR TITLE
Feature / Controller cleanup

### DIFF
--- a/Config/DatabaseConfig.php
+++ b/Config/DatabaseConfig.php
@@ -8,4 +8,13 @@ class DatabaseConfig
     public const DATABASE = 'iproject3';
     public const USER = 'iproject3';
     public const PASSWORD = 'aeedZ8u8';
+    
+    /**
+     * Returns the DSN needed for the database connection with PDO.
+     * @return string
+     */
+    public static function getDSN(): string
+    {
+        return "sqlsrv:server=" . self::HOST . "; Database=" . self::DATABASE;
+    }
 }

--- a/Controllers/UserController.php
+++ b/Controllers/UserController.php
@@ -5,7 +5,6 @@ namespace Controllers;
 use Interfaces\IController;
 use Core\Database;
 use Error;
-use PDOException;
 
 /**
  * User Controller

--- a/Controllers/UserController.php
+++ b/Controllers/UserController.php
@@ -28,58 +28,39 @@ class UserController implements IController
     {
         $this->database = new Database();
     }
-
+    
     public function create(array $data): ?array
     {
-        try {
-            $this->database->create(self::$table, $data);
-            return $this->database->getByColumn(self::$table, 'email', $data['email']);
-        } catch (Error $error) {
-            throw new Error("Gebruiker kon niet aangemaakt worden!");
-        }
+        $this->database->create(self::$table, $data);
+        
+        return $this->database->getByColumn(self::$table, 'email', $data['email']);
     }
 
     public function get(int $id): ?array
     {
-        try {
-            return $this->database->get(self::$table, $id);
-        } catch (Error $error) {
-            throw new Error("Gebruiker, waarvan ID = $id, niet gevonden!");
-        }
+        return $this->database->get(self::$table, $id);
     }
 
     public function index(): ?array
     {
-        try {
-            return $this->database->index(self::$table);
-        } catch (Error $error) {
-            throw new Error("Geen gebruikers gevonden!");
-        }
+        return $this->database->index(self::$table);
     }
 
     public function update(int $id, array $data): ?array
     {
-        // First check if item exists.
-        $this->get($id);
-
-        try {
+        if ($this->get($id)) {
             $this->database->update(self::$table, $id, $data);
-            return $this->get($id);
-        } catch (Error $error) {
-            throw new Error("Gebruiker, waarvan ID = $id, niet geupdate!");
         }
+        
+        return $this->get($id) ?? null;
     }
 
     public function delete(int $id): ?array
     {
-        // First check if item exists.
-        $user = $this->get($id);
-
-        try {
+        if ($user = $this->get($id)) {
             $this->database->delete(self::$table, $id);
-            return $user;   // Return deleted user when success.
-        } catch (Error $error) {
-            throw new Error("Gebruiker, waarvan ID = $id, niet verwijderd!");
         }
+        
+        return $user ?? null;
     }
 }

--- a/Controllers/UserController.php
+++ b/Controllers/UserController.php
@@ -26,7 +26,7 @@ class UserController implements IController
 
     public function __construct()
     {
-        $this->database = new Database();
+        $this->database = new Database;
     }
     
     public function create(array $data): ?array

--- a/Controllers/UserController.php
+++ b/Controllers/UserController.php
@@ -4,7 +4,6 @@ namespace Controllers;
 
 use Interfaces\IController;
 use Core\Database;
-use Error;
 
 /**
  * User Controller

--- a/Core/Database.php
+++ b/Core/Database.php
@@ -10,11 +10,11 @@ use Error;
 
 /**
  * Database Class
- * 
+ *
  * In this class you find all generic CRUD operations to be used in Controller classes.
- * 
+ *
  * TODO: Dubbele code eruit halen!
- * 
+ *
  */
 class Database
 {
@@ -124,7 +124,7 @@ class Database
      * Read method to be used in Controllers.
      * @param   string  $table      Table to fetch data from.
      * @param   string  $column     Row where column = 'value'.
-     * @param   string  $value      
+     * @param   string  $value      Value to check for in table.
      * @return  array               Returns fetched row as an associative Arrays.
      * @throws  Error               Throws error when nothing was found or when execution fails (SQL related).
      */
@@ -147,7 +147,7 @@ class Database
 
         $this->close();
 
-        if ($result && sizeof($result) > 0) {
+        if (!empty($result)) {
             return $result;
         } else {
             throw new Error("[Database] No rows where $column = '$value' found!");
@@ -179,9 +179,7 @@ class Database
 
         $this->close();
 
-        // exit ($result);
-
-        if ($result && sizeof($result) > 0) {
+        if (!empty($result)) {
             return $result;
         } else {
             throw new Error("[Database] No rows found!");
@@ -190,10 +188,9 @@ class Database
 
     /**
      * Update method to be used in Controllers.
-     * @param   string  $table  Update row in which table?
-     * @param   int     $id     Row with ID?
-     * @param   void    $data   Associative array of which the key is the column name to be updated with its value.
-     * @throws  Error           Throws error when execution fails. Possible cause: SQL conflicts
+     * @param string $table Update row in which table?
+     * @param int    $id    Row with ID?
+     * @param array  $data  Associative array of which the key is the column name to be updated with its value.
      */
     public function update(string $table, int $id, array $data): void
     {
@@ -282,7 +279,11 @@ class Database
 
         return $buffer;
     }
-
+    
+    /**
+     * Handles PDO Exceptions with HTML output.
+     * @param string $message
+     */
     private function handlePDOException(string $message): void
     {
         echo '<div class="alert alert-danger" role="alert">' . $message . ' </div>';

--- a/Core/Database.php
+++ b/Core/Database.php
@@ -35,11 +35,7 @@ class Database
     private function connect(): void
     {
         try {
-            $this->pdo = new PDO(
-                "sqlsrv:server=" . DatabaseConfig::HOST . "; Database=" . DatabaseConfig::DATABASE,
-                DatabaseConfig::USER,
-                DatabaseConfig::PASSWORD
-            );
+            $this->pdo = new PDO(DatabaseConfig::getDSN(), DatabaseConfig::USER, DatabaseConfig::PASSWORD);
 
             // Uncomment bottom line when debugging
             $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);

--- a/Core/Database.php
+++ b/Core/Database.php
@@ -69,18 +69,11 @@ class Database
 
         $columns = implode(', ', array_keys($data));
         $values  = $this->formatInsertValues(array_values($data));
-
-        $query = "INSERT INTO $table ($columns) VALUES ($values)";
-
-        $this->sth = $this->dbh->prepare($query);
+        
+        $this->sth = $this->dbh->prepare("INSERT INTO $table ($columns) VALUES ($values)");
 
         $this->execute();
-
         $this->close();
-
-        if (!isset($result) || !$result) {
-            throw new Error("[Database] Error executing create query!");
-        }
     }
 
     /**
@@ -94,8 +87,9 @@ class Database
     {
         $this->connect();
 
-        $this->sth = $this->dbh->prepare("SELECT * FROM $table where ID = :id");
-        $this->sth->bindParam(':id', $id, PDO::PARAM_INT);
+        $this->sth = $this->dbh
+            ->prepare("SELECT * FROM $table where ID = :id")
+            ->bindParam(':id', $id, PDO::PARAM_INT);
 
         $this->execute();
 
@@ -103,11 +97,7 @@ class Database
 
         $this->close();
 
-        if (!empty($result)) {
-            return $result;
-        } else {
-            throw new Error("[Database] Row where ID = $id not found!");
-        }
+        return !empty($result) ? $result : null;
     }
 
     /**
@@ -122,8 +112,9 @@ class Database
     {
         $this->connect();
         
-        $this->sth = $this->dbh->prepare("SELECT * FROM $table where $column = :value");
-        $this->sth->bindParam(':value', $value, PDO::PARAM_STR);
+        $this->sth = $this->dbh
+            ->prepare("SELECT * FROM $table where $column = :value")
+            ->bindParam(':value', $value, PDO::PARAM_STR);
 
         $this->execute();
 
@@ -131,11 +122,7 @@ class Database
 
         $this->close();
 
-        if (!empty($result)) {
-            return $result;
-        } else {
-            throw new Error("[Database] No rows where $column = '$value' found!");
-        }
+        return !empty($result) ? $result : null;
     }
 
     /**
@@ -156,11 +143,7 @@ class Database
 
         $this->close();
 
-        if (!empty($result)) {
-            return $result;
-        } else {
-            throw new Error("[Database] No rows found!");
-        }
+        return !empty($result) ? $result : null;
     }
 
     /**
@@ -173,16 +156,12 @@ class Database
     {
         $this->connect();
         
-        $this->sth = $this->dbh->prepare("UPDATE $table SET " . $this->formatUpdateValues($data) . " WHERE ID = :id");
-        $this->sth->bindParam(':id', $id, PDO::PARAM_INT);
+        $this->sth = $this->dbh
+            ->prepare("UPDATE $table SET " . $this->formatUpdateValues($data) . " WHERE ID = :id")
+            ->bindParam(':id', $id, PDO::PARAM_INT);
 
-        $result = $this->execute();
-
+        $this->execute();
         $this->close();
-
-        if (!$result) {
-            throw new Error("[Database] Error executing update query!");
-        }
     }
 
     /**
@@ -196,16 +175,12 @@ class Database
     {
         $this->connect();
         
-        $this->sth = $this->dbh->prepare("DELETE FROM $table WHERE ID = :id");
-        $this->sth->bindParam(':id', $id, PDO::PARAM_INT);
+        $this->sth = $this->dbh
+            ->prepare("DELETE FROM $table WHERE ID = :id")
+            ->bindParam(':id', $id, PDO::PARAM_INT);
     
-        $result = $this->execute();
-
+        $this->execute();
         $this->close();
-
-        if (!$result) {
-            throw new Error("[Database] Error executing delete query!");
-        }
     }
     
     /**
@@ -235,10 +210,7 @@ class Database
             $buffer .= is_numeric($value) ? "$key = $value, " :  "$key = '$value', ";
         }
 
-        $buffer = trim($buffer, " "); // Trim last space
-        $buffer = trim($buffer, ","); // Trim trailing comma        
-
-        return $buffer;
+        return trim($buffer, ", ");
     }
     
     /**

--- a/Core/Database.php
+++ b/Core/Database.php
@@ -19,14 +19,14 @@ use Error;
 class Database
 {
     /**
-     * @var PDO $dbh PDO Handler also known as the database handler aka the database connection.
+     * @var PDO $pdo PDO Handler also known as the database handler aka the database connection.
      */
-    private $dbh;
+    private $pdo;
 
     /**
-     * @var PDOStatement $sth Statement handler.
+     * @var PDOStatement $statement Statement handler.
      */
-    private $sth;
+    private $statement;
 
     /**
      * Connect to the database.
@@ -35,14 +35,14 @@ class Database
     private function connect(): void
     {
         try {
-            $this->dbh = new PDO(
+            $this->pdo = new PDO(
                 "sqlsrv:server=" . DatabaseConfig::HOST . "; Database=" . DatabaseConfig::DATABASE,
                 DatabaseConfig::USER,
                 DatabaseConfig::PASSWORD
             );
 
             // Uncomment bottom line when debugging
-            $this->dbh->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch (PDOException $ex) {
             $this->handlePDOException($ex->getMessage());
         }
@@ -54,7 +54,7 @@ class Database
      */
     private function close(): void
     {
-        unset($this->sth, $this->dbh);
+        unset($this->statement, $this->pdo);
     }
 
     /**
@@ -62,7 +62,6 @@ class Database
      * @param  string $table Table to insert data in.
      * @param  array  $data  Associative array of which the key represents the column name.
      * @return void
-     * @throws Error         Throws error when execution fails. Possible cause: SQL conflicts
      */
     public function create(string $table, array $data): void
     {
@@ -71,7 +70,7 @@ class Database
         $columns = implode(', ', array_keys($data));
         $values  = $this->formatInsertValues(array_values($data));
         
-        $this->sth = $this->dbh->prepare("INSERT INTO $table ($columns) VALUES ($values)");
+        $this->statement = $this->pdo->prepare("INSERT INTO $table ($columns) VALUES ($values)");
 
         $this->execute();
         $this->close();
@@ -82,13 +81,12 @@ class Database
      * @param  string $table Table to fetch data from.
      * @param  int    $id    Row with ID.
      * @return array         Returns fetched row as an associative array.
-     * @throws Error         Throws error when nothing was found or when execution fails (SQL related).
      */
     public function get(string $table, int $id): ?array
     {
         $this->connect();
 
-        $this->sth = $this->dbh
+        $this->statement = $this->pdo
             ->prepare("SELECT * FROM $table where ID = :id")
             ->bindParam(':id', $id, PDO::PARAM_INT);
 
@@ -107,13 +105,12 @@ class Database
      * @param  string $column Row where column = 'value'.
      * @param  string $value  Value to check for in table.
      * @return array          Returns fetched row as an associative Arrays.
-     * @throws Error          Throws error when nothing was found or when execution fails (SQL related).
      */
     public function getByColumn(string $table, string $column, string $value): ?array
     {
         $this->connect();
         
-        $this->sth = $this->dbh
+        $this->statement = $this->pdo
             ->prepare("SELECT * FROM $table where $column = :value")
             ->bindParam(':value', $value, PDO::PARAM_STR);
 
@@ -130,13 +127,12 @@ class Database
      * Read method to be used in Controllers.
      * @param  string $table Table to fetch data from.
      * @return array         Returns numeric array with all rows (as an associative arrays).
-     * @throws Error         Throws error when nothing was found or when execution fails (SQL related).
      */
     public function index(string $table): ?array
     {
         $this->connect();
         
-        $this->sth = $this->dbh->prepare("SELECT * FROM $table");
+        $this->statement = $this->pdo->prepare("SELECT * FROM $table");
 
         $result = $this
             ->execute()
@@ -157,7 +153,7 @@ class Database
     {
         $this->connect();
         
-        $this->sth = $this->dbh
+        $this->statement = $this->pdo
             ->prepare("UPDATE $table SET " . $this->formatUpdateValues($data) . " WHERE ID = :id")
             ->bindParam(':id', $id, PDO::PARAM_INT);
 
@@ -170,13 +166,12 @@ class Database
      * @param  string $table Table to delete a row
      * @param  int    $id    Delete row where ID = ?
      * @return void          Returns nothing.
-     * @throws Error         Throws error when execution fails. Possible cause: SQL conflicts
      */
     public function delete(string $table, int $id): void
     {
         $this->connect();
         
-        $this->sth = $this->dbh
+        $this->statement = $this->pdo
             ->prepare("DELETE FROM $table WHERE ID = :id")
             ->bindParam(':id', $id, PDO::PARAM_INT);
     
@@ -230,11 +225,11 @@ class Database
     private function execute(): PDOStatement
     {
         try {
-            $this->sth->execute();
+            $this->statement->execute();
         } catch (PDOException $ex) {
             $this->handlePDOException($ex->getMessage());
         }
         
-        return $this->sth;
+        return $this->statement;
     }
 }

--- a/Core/Database.php
+++ b/Core/Database.php
@@ -6,7 +6,6 @@ use Config\DatabaseConfig;
 use PDO;
 use PDOStatement;
 use PDOException;
-use Error;
 
 /**
  * Database Class

--- a/Core/Database.php
+++ b/Core/Database.php
@@ -30,6 +30,7 @@ class Database
 
     /**
      * Connect to the database.
+     * @return void
      */
     private function connect(): void
     {
@@ -48,20 +49,20 @@ class Database
     }
 
     /**
-     * Close the database connection.
+     * Close the database connection and un-initializes the statement handler.
+     * @return void
      */
     private function close(): void
     {
-        unset($this->sth);
-        $this->dbh = null;
+        unset($this->sth, $this->dbh);
     }
 
     /**
      * Create method to be used in Controllers.
-     * @param   string  $table  Table to insert data in.
-     * @param   array   $data   Associative array of which the key represents the column name.
-     * @return  void            Returns nothing.
-     * @throws  Error           Throws error when execution fails. Possible cause: SQL conflicts
+     * @param  string $table Table to insert data in.
+     * @param  array  $data  Associative array of which the key represents the column name.
+     * @return void
+     * @throws Error         Throws error when execution fails. Possible cause: SQL conflicts
      */
     public function create(string $table, array $data): void
     {
@@ -78,10 +79,10 @@ class Database
 
     /**
      * Read method to be used in Controllers.
-     * @param   string  $table  Table to fetch data from.
-     * @param   int     $id     Row with ID.
-     * @return  array           Returns fetched row as an associative array.
-     * @throws  Error           Throws error when nothing was found or when execution fails (SQL related).
+     * @param  string $table Table to fetch data from.
+     * @param  int    $id    Row with ID.
+     * @return array         Returns fetched row as an associative array.
+     * @throws Error         Throws error when nothing was found or when execution fails (SQL related).
      */
     public function get(string $table, int $id): ?array
     {
@@ -91,9 +92,9 @@ class Database
             ->prepare("SELECT * FROM $table where ID = :id")
             ->bindParam(':id', $id, PDO::PARAM_INT);
 
-        $this->execute();
-
-        $result = $this->sth->fetch(PDO::FETCH_ASSOC);
+        $result = $this
+            ->execute()
+            ->fetch(PDO::FETCH_ASSOC);
 
         $this->close();
 
@@ -102,11 +103,11 @@ class Database
 
     /**
      * Read method to be used in Controllers.
-     * @param   string  $table      Table to fetch data from.
-     * @param   string  $column     Row where column = 'value'.
-     * @param   string  $value      Value to check for in table.
-     * @return  array               Returns fetched row as an associative Arrays.
-     * @throws  Error               Throws error when nothing was found or when execution fails (SQL related).
+     * @param  string $table  Table to fetch data from.
+     * @param  string $column Row where column = 'value'.
+     * @param  string $value  Value to check for in table.
+     * @return array          Returns fetched row as an associative Arrays.
+     * @throws Error          Throws error when nothing was found or when execution fails (SQL related).
      */
     public function getByColumn(string $table, string $column, string $value): ?array
     {
@@ -116,9 +117,9 @@ class Database
             ->prepare("SELECT * FROM $table where $column = :value")
             ->bindParam(':value', $value, PDO::PARAM_STR);
 
-        $this->execute();
-
-        $result = $this->sth->fetch(PDO::FETCH_ASSOC);
+        $result = $this
+            ->execute()
+            ->fetch(PDO::FETCH_ASSOC);
 
         $this->close();
 
@@ -127,9 +128,9 @@ class Database
 
     /**
      * Read method to be used in Controllers.
-     * @param   string  $table  Table to fetch data from.
-     * @return  array           Returns numeric array with all rows (as an associative arrays).
-     * @throws  Error           Throws error when nothing was found or when execution fails (SQL related).
+     * @param  string $table Table to fetch data from.
+     * @return array         Returns numeric array with all rows (as an associative arrays).
+     * @throws Error         Throws error when nothing was found or when execution fails (SQL related).
      */
     public function index(string $table): ?array
     {
@@ -137,9 +138,9 @@ class Database
         
         $this->sth = $this->dbh->prepare("SELECT * FROM $table");
 
-        $this->execute();
-
-        $result = $this->sth->fetchAll(PDO::FETCH_ASSOC);
+        $result = $this
+            ->execute()
+            ->fetchAll(PDO::FETCH_ASSOC);
 
         $this->close();
 
@@ -166,10 +167,10 @@ class Database
 
     /**
      * Delete method to be used in Controllers.
-     * @param   string  $table  Table to delete a row
-     * @param   int     $id     Delete row where ID = ?
-     * @return  void            Returns nothing.
-     * @throws  Error           Throws error when execution fails. Possible cause: SQL conflicts
+     * @param  string $table Table to delete a row
+     * @param  int    $id    Delete row where ID = ?
+     * @return void          Returns nothing.
+     * @throws Error         Throws error when execution fails. Possible cause: SQL conflicts
      */
     public function delete(string $table, int $id): void
     {
@@ -185,8 +186,8 @@ class Database
     
     /**
      * Function to prepare an array of values for the SQL INSERT INTO statement.
-     * @param   array   $values     Values to be formatted/prepared.
-     * @return  string              String formatted as follows: 'value1', 'value2', 'value3'
+     * @param   array  $values Values to be formatted/prepared.
+     * @return  string         String formatted as follows: 'value1', 'value2', 'value3'
      */
     private function formatInsertValues(array $values): string
     {
@@ -199,8 +200,8 @@ class Database
 
     /**
      * Function to prepare an array of values for the SQL UPDATE statement.
-     * @param   array   $array  Array with key (columns) and value (to update) pairs.
-     * @return  string          String formatted as follows: 'column1' = 'value1', 'column2' = 'value2'
+     * @param   array  $array Array with key (columns) and value (to update) pairs.
+     * @return  string        String formatted as follows: 'column1' = 'value1', 'column2' = 'value2'
      */
     private function formatUpdateValues(array $array): string
     {
@@ -223,17 +224,17 @@ class Database
     }
     
     /**
-     * Execute Statement handler preparation and return it's value.
-     * @return bool
+     * Execute Statement handler.
+     * @return PDOStatement The statement handler for chaining.
      */
-    private function execute(): bool
+    private function execute(): PDOStatement
     {
         try {
-            $result = $this->sth->execute();
+            $this->sth->execute();
         } catch (PDOException $ex) {
             $this->handlePDOException($ex->getMessage());
         }
         
-        return $result ?? false;
+        return $this->sth;
     }
 }

--- a/Core/Database.php
+++ b/Core/Database.php
@@ -61,16 +61,17 @@ class Database
      */
     public function create(string $table, array $data): void
     {
-        $this->withConnection(function() use ($table, $data)
-        {
-            $columns = Formatter::formatInsertColumns($data);
-            $values  = Formatter::formatInsertValues($data);
-    
-            $this->statement = $this->pdo
-                ->prepare("INSERT INTO $table ($columns) VALUES ($values)");
-    
-            $this->execute();
-        });
+        $this->connect();
+        
+        $columns = Formatter::formatInsertColumns($data);
+        $values  = Formatter::formatInsertValues($data);
+
+        $this->statement = $this->pdo
+            ->prepare("INSERT INTO $table ($columns) VALUES ($values)");
+
+        $this->execute();
+        
+        $this->close();
     }
 
     /**
@@ -81,16 +82,17 @@ class Database
      */
     public function get(string $table, int $id): ?array
     {
-        $result = $this->withConnection(function() use ($table, $id)
-        {
-            $this->statement = $this->pdo
-                ->prepare("SELECT * FROM $table where ID = :id")
-                ->bindParam(':id', $id, PDO::PARAM_INT);
-    
-            return $this
-                ->execute()
-                ->fetch(PDO::FETCH_ASSOC);
-        });
+        $this->connect();
+        
+        $this->statement = $this->pdo
+            ->prepare("SELECT * FROM $table where ID = :id")
+            ->bindParam(':id', $id, PDO::PARAM_INT);
+
+        $result = $this
+            ->execute()
+            ->fetch(PDO::FETCH_ASSOC);
+            
+        $this->close();
 
         return !empty($result) ? $result : null;
     }
@@ -104,16 +106,18 @@ class Database
      */
     public function getByColumn(string $table, string $column, string $value): ?array
     {
-        $result = $this->withConnection(function() use ($column, $table, $value)
-        {
-            $this->statement = $this->pdo
-                ->prepare("SELECT * FROM $table where $column = :value")
-                ->bindParam(':value', $value, PDO::PARAM_STR);
-    
-            return $this
-                ->execute()
-                ->fetch(PDO::FETCH_ASSOC);
-        });
+        $this->connect();
+        
+        $this->statement = $this->pdo
+            ->prepare("SELECT * FROM $table where $column = :value")
+            ->bindParam(':value', $value, PDO::PARAM_STR);
+
+        $result = $this
+            ->execute()
+            ->fetch(PDO::FETCH_ASSOC);
+        
+        $this->close();
+      
 
         return !empty($result) ? $result : null;
     }
@@ -125,14 +129,15 @@ class Database
      */
     public function index(string $table): ?array
     {
-        $result = $this->withConnection(function() use ($table)
-        {
-            $this->statement = $this->pdo->prepare("SELECT * FROM $table");
-    
-            return $this
-                ->execute()
-                ->fetchAll(PDO::FETCH_ASSOC);
-        });
+        $this->connect();
+        
+        $this->statement = $this->pdo->prepare("SELECT * FROM $table");
+
+        $result = $this
+            ->execute()
+            ->fetchAll(PDO::FETCH_ASSOC);
+            
+        $this->close();
 
         return !empty($result) ? $result : null;
     }
@@ -145,14 +150,14 @@ class Database
      */
     public function update(string $table, int $id, array $data): void
     {
-        $this->withConnection(function() use ($table, $id, $data)
-        {
-            $this->statement = $this->pdo
-                ->prepare("UPDATE $table SET " . Formatter::formatUpdateValues($data) . " WHERE ID = :id")
-                ->bindParam(':id', $id, PDO::PARAM_INT);
-    
-            $this->execute();
-        });
+        $this->connect();
+        
+        $this->statement = $this->pdo
+            ->prepare("UPDATE $table SET " . Formatter::formatUpdateValues($data) . " WHERE ID = :id")
+            ->bindParam(':id', $id, PDO::PARAM_INT);
+
+        $this->execute();
+        $this->close();
     }
 
     /**
@@ -163,14 +168,14 @@ class Database
      */
     public function delete(string $table, int $id): void
     {
-        $this->withConnection(function() use ($table, $id)
-        {
-            $this->statement = $this->pdo
-                ->prepare("DELETE FROM $table WHERE ID = :id")
-                ->bindParam(':id', $id, PDO::PARAM_INT);
-    
-            $this->execute();
-        });
+        $this->connect();
+        
+        $this->statement = $this->pdo
+            ->prepare("DELETE FROM $table WHERE ID = :id")
+            ->bindParam(':id', $id, PDO::PARAM_INT);
+
+        $this->execute();
+        $this->close();
     }
     
     /**
@@ -195,19 +200,5 @@ class Database
         }
         
         return $this->statement;
-    }
-    
-    /**
-     * withConnections an auto connect and auto close simplified.
-     * @param  $function Closure The function that you want to be called in between connections
-     * @return           mixed
-     */
-    private function withConnection(Closure $function)
-    {
-        $this->connect();
-        $result = $function();
-        $this->close();
-        
-        return $result;
     }
 }

--- a/Core/Database.php
+++ b/Core/Database.php
@@ -74,15 +74,11 @@ class Database
 
         $this->sth = $this->dbh->prepare($query);
 
-        try {
-            $result = $this->sth->execute();
-        } catch (PDOException $ex) {
-            $this->handlePDOException($ex->getMessage());
-        }
+        $this->execute();
 
         $this->close();
 
-        if ($result === false) {
+        if (!isset($result) || !$result) {
             throw new Error("[Database] Error executing create query!");
         }
     }
@@ -98,22 +94,16 @@ class Database
     {
         $this->connect();
 
-        $query = "SELECT * FROM $table where ID = :id";
-
-        $this->sth = $this->dbh->prepare($query);
+        $this->sth = $this->dbh->prepare("SELECT * FROM $table where ID = :id");
         $this->sth->bindParam(':id', $id, PDO::PARAM_INT);
 
-        try {
-            $this->sth->execute();
-        } catch (PDOException $ex) {
-            $this->handlePDOException($ex->getMessage());
-        }
+        $this->execute();
 
         $result = $this->sth->fetch(PDO::FETCH_ASSOC);
 
         $this->close();
 
-        if ($result && sizeof($result) > 0) {
+        if (!empty($result)) {
             return $result;
         } else {
             throw new Error("[Database] Row where ID = $id not found!");
@@ -131,17 +121,11 @@ class Database
     public function getByColumn(string $table, string $column, string $value): ?array
     {
         $this->connect();
-
-        $query = "SELECT * FROM $table where $column = :value";
-
-        $this->sth = $this->dbh->prepare($query);
+        
+        $this->sth = $this->dbh->prepare("SELECT * FROM $table where $column = :value");
         $this->sth->bindParam(':value', $value, PDO::PARAM_STR);
 
-        try {
-            $this->sth->execute();
-        } catch (PDOException $ex) {
-            $this->handlePDOException($ex->getMessage());
-        }
+        $this->execute();
 
         $result = $this->sth->fetch(PDO::FETCH_ASSOC);
 
@@ -163,17 +147,10 @@ class Database
     public function index(string $table): ?array
     {
         $this->connect();
+        
+        $this->sth = $this->dbh->prepare("SELECT * FROM $table");
 
-        // Query
-        $query = "SELECT * FROM $table";
-
-        $this->sth = $this->dbh->prepare($query);
-
-        try {
-            $this->sth->execute();
-        } catch (PDOException $ex) {
-            $this->handlePDOException($ex->getMessage());
-        }
+        $this->execute();
 
         $result = $this->sth->fetchAll(PDO::FETCH_ASSOC);
 
@@ -195,18 +172,11 @@ class Database
     public function update(string $table, int $id, array $data): void
     {
         $this->connect();
-
-        $query = "UPDATE $table SET " . $this->formatUpdateValues($data) . " WHERE ID = :id";
-
-        $this->sth = $this->dbh->prepare($query);
+        
+        $this->sth = $this->dbh->prepare("UPDATE $table SET " . $this->formatUpdateValues($data) . " WHERE ID = :id");
         $this->sth->bindParam(':id', $id, PDO::PARAM_INT);
 
-        try {
-            $result = $this->sth->execute();
-        } catch (PDOException $ex) {
-            $this->handlePDOException($ex->getMessage());
-        }
-
+        $result = $this->execute();
 
         $this->close();
 
@@ -225,18 +195,11 @@ class Database
     public function delete(string $table, int $id): void
     {
         $this->connect();
-
-        $query = "DELETE FROM $table WHERE ID = :id";
-
-        $this->sth = $this->dbh->prepare($query);
+        
+        $this->sth = $this->dbh->prepare("DELETE FROM $table WHERE ID = :id");
         $this->sth->bindParam(':id', $id, PDO::PARAM_INT);
-
-        try {
-            $result = $this->sth->execute();
-        } catch (PDOException $ex) {
-            $this->handlePDOException($ex->getMessage());
-        }
-
+    
+        $result = $this->execute();
 
         $this->close();
 
@@ -244,9 +207,7 @@ class Database
             throw new Error("[Database] Error executing delete query!");
         }
     }
-
-
-    // Helper Functions
+    
     /**
      * Function to prepare an array of values for the SQL INSERT INTO statement.
      * @param   array   $values     Values to be formatted/prepared.
@@ -287,5 +248,20 @@ class Database
     private function handlePDOException(string $message): void
     {
         echo '<div class="alert alert-danger" role="alert">' . $message . ' </div>';
+    }
+    
+    /**
+     * Execute Statement handler preparation and return it's value.
+     * @return bool
+     */
+    private function execute(): bool
+    {
+        try {
+            $result = $this->sth->execute();
+        } catch (PDOException $ex) {
+            $this->handlePDOException($ex->getMessage());
+        }
+        
+        return $result ?? false;
     }
 }

--- a/Core/Formatter.php
+++ b/Core/Formatter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Core;
+
+class Formatter
+{
+    /**
+     * Function to prepare an array of values for the SQL UPDATE statement.
+     * @param array $values Array with key (columns) and value (to update) pairs.
+     * @return  string      String formatted as follows: 'column1' = 'value1', 'column2' = 'value2'
+     */
+    public static function formatUpdateValues(array $values): string
+    {
+        $buffer = "";
+    
+        foreach ($values as $key => $value) {
+            $buffer .= is_numeric($value) ? "$key = $value, " :  "$key = '$value', ";
+        }
+    
+        return trim($buffer, ", ");
+    }
+    
+    /**
+     * Method to prepare an array of columns for the SQL UPDATE statement.
+     * @param   array $data
+     * @return  string      String formatted as follows: 'column1' = 'value1', 'column2' = 'value2'
+     */
+    public static function formatInsertColumns(array $data): string
+    {
+        return implode(', ', array_keys($data));
+    }
+    
+    /**
+     * method to prepare an array of values for the SQL UPDATE statement.
+     * @param   array $data
+     * @return  string      String formatted as follows: 'column1' = 'value1', 'column2' = 'value2'
+     */
+    public static function formatInsertValues(array $data): string
+    {
+        $values = array_keys($data);
+        
+        foreach ($values as &$value) {
+            $value = "'$value'";
+        }
+        
+        return implode(', ', $values);
+    }
+}

--- a/Core/Formatter.php
+++ b/Core/Formatter.php
@@ -2,6 +2,10 @@
 
 namespace Core;
 
+/**
+ * Class Formatter
+ * @package Core
+ */
 class Formatter
 {
     /**


### PR DESCRIPTION
@ilivss Hey, check maar even wat je er van vind.

Dingen die er veranderd zijn:
1. Error throwing op een plek staan. Zodat dit veel code scheelt.
2. PDO Prepare en bind methods gechained voor cleaner code.
3. Statement handler error catching in een methode omdat dat vaak herhaalt wordt en hierdoor chaining mogelijk wordt.
4. Naamgeving veranderd sth -> statement, dbh -> pdo. (logischer en leesbaarder als je het voor het eerst ziet.
5. UserController versimpelt.
7. Formatter helper klasse omdat ik dat wel een klasse op zich waard vondt.

Over het algemeen scheelt dit op deze manier 45 regels code en is naar mijn mening de security er niet minder op geworden. Er wordt namelijk nog steeds een error message laten zien als er iets fout gaat op query niveau en een exit() op connection niveau. Niet mergen ik heb deze code nog niet getest maar ik neem aan dat het vrijwel allemaal gelijk werkt.

**Laat me weten als je het ergens niet mee eens bent!**